### PR TITLE
Use collections to auto generate the index

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,8 @@ baseurl: /dataone_lessons
 
 # Format for the slides, can be either 16:9 or 4:3
 format: '4:3'
+
+# Collections
+collections:
+  lessons:
+    output: false

--- a/_lessons
+++ b/_lessons
@@ -1,0 +1,1 @@
+lessons

--- a/index.md
+++ b/index.md
@@ -5,17 +5,6 @@ layout: index
 
 # DataONE Data Management Education Modules
 
-- [Markdown basics][00]
-- [Why Data Management][01]
-- [Data Sharing][02]
-- [Data Management Planning][03]
-- [Data Protection and Backups][06]
-- [Legal and Policy Issues][10]
-
-[00]: lessons/00_markdown/
-[01]: lessons/01_management/
-[02]: lessons/02_datasharing/
-[03]: lessons/03_planning/
-[05]: lessons/05_qaqc/
-[06]: lessons/06_protect/
-[10]: lessons/10_policy/
+{% for lesson in site.lessons %}
+- [{{ lesson.title }}]({{ site.baseurl }}{{ lesson.url }})
+{% endfor %}


### PR DESCRIPTION
This is a bit dirtier than I would like, but it works.

The solution is to have a symlink from `lessons` to `_lessons`, where `_lessons` is a collection which is **not** rendered, but still give access to its metadata. I don't like what jekyll is doing to my brain.